### PR TITLE
Initial import of expert expectations

### DIFF
--- a/docs/experts/expectations.md
+++ b/docs/experts/expectations.md
@@ -1,0 +1,49 @@
+---
+layout: page
+title: "Experts: Expectations"
+---
+
+## Your Responsibilities
+
+### Communication
+
+At the start of each work session, publish a self-stand-up via Slack, to include:
+
+- What you achieved last session
+- What Jira ticket you will be working on this session
+
+You must flag via Slack when you are running low on work.
+We'll then work with you to line up the next series of Jira tickets.
+
+### Order, Scope, Venue and Commitment
+
+- Work on Jira tickets only, in priority order
+- Update them with comments and by moving them across columns
+- Where you're working on something open source, prefer to interact with linked issues via GitHub's interface - this 'Github First' approach is important to some teams (for example, the SDK Team)
+- Commit to the minimum number of regular hours you have agreed with us
+
+## Ably's Responsibilities
+
+We recognise that the relationship we're building with the freelancers that work with us is deeply symbiotic in nature, therefore we want to make it clear what we want to commit to you.
+
+We'll:
+
+- Make sure there are enough Jira tickets at any one time
+- Make sure Jira tickets are prioritised
+- Group Jira tickets into milestones or releases, so we can aim for tangible advances
+- Review your work in a timely manner
+
+## Technology needs Humanity
+
+This is one of Ably's [core values](https://ably.com/blog/ably-values),
+also sometimes abbreviated to 'tech needs humanity'.
+
+We mention it here because we want to explicitly acknowledge that we're all humans.
+This means that we know we'll all make mistakes at times, or perhaps not quite match up to expectations all of the time. :heart:
+
+In the same way that we will do our best to remain flexible where possible and understand when things aren't going as well as they could be for you in respect of matching up to your responsibilities, we expect the same from you. We are a fast growing company with individuals who, day-to-day, have to wear many hats and spin many plates at times. Please bear with us if we can't always match up to our responsibilities as outlined above. :smile:
+
+## Definitions
+
+- **work session**: This should be interpreted as "every time you come online after a period of significant break lasting more than a few hours". There is flexibility to bend this definition but that will depend on the needs of the team you are working with.
+- **via Slack**: This will depend on the team you are working with, however the appropriate channel to feed your updates into will be clearly indicated to you by us.

--- a/docs/experts/expectations.md
+++ b/docs/experts/expectations.md
@@ -20,12 +20,12 @@ At the start of each work session, publish a self-stand-up via Slack, to include
 You must flag via Slack when you are running low on work.
 We'll then work with you to line up the next series of Jira tickets.
 
-### Order, Scope, Venue and Commitment
+### Commitment, Order, Scope and Venue
 
+- Commit to the minimum number of regular hours you have agreed with us
 - Work on Jira tickets only, in priority order
 - Update them with comments and by moving them across columns
 - Where you're working on something open source, prefer to interact with linked issues via GitHub's interface - this 'Github First' approach is important to some teams (for example, the SDK Team)
-- Commit to the minimum number of regular hours you have agreed with us
 
 ## Ably's Responsibilities
 

--- a/docs/experts/expectations.md
+++ b/docs/experts/expectations.md
@@ -3,6 +3,11 @@ layout: page
 title: "Experts: Expectations"
 ---
 
+## Definitions
+
+- **work session**: This should be interpreted as "every time you come online after a period of significant break lasting more than a few hours". There is flexibility to bend this definition but that will depend on the needs of the team you are working with.
+- **via Slack**: This will depend on the team you are working with, however the appropriate channel to feed your updates into will be clearly indicated to you by us.
+
 ## Your Responsibilities
 
 ### Communication
@@ -42,8 +47,3 @@ We mention it here because we want to explicitly acknowledge that we're all huma
 This means that we know we'll all make mistakes at times, or perhaps not quite match up to expectations all of the time. :heart:
 
 In the same way that we will do our best to remain flexible where possible and understand when things aren't going as well as they could be for you in respect of matching up to your responsibilities, we expect the same from you. We are a fast growing company with individuals who, day-to-day, have to wear many hats and spin many plates at times. Please bear with us if we can't always match up to our responsibilities as outlined above. :smile:
-
-## Definitions
-
-- **work session**: This should be interpreted as "every time you come online after a period of significant break lasting more than a few hours". There is flexibility to bend this definition but that will depend on the needs of the team you are working with.
-- **via Slack**: This will depend on the team you are working with, however the appropriate channel to feed your updates into will be clearly indicated to you by us.

--- a/docs/experts/expectations.md
+++ b/docs/experts/expectations.md
@@ -46,4 +46,5 @@ also sometimes abbreviated to 'tech needs humanity'.
 We mention it here because we want to explicitly acknowledge that we're all humans.
 This means that we know we'll all make mistakes at times, or perhaps not quite match up to expectations all of the time. :heart:
 
-In the same way that we will do our best to remain flexible where possible and understand when things aren't going as well as they could be for you in respect of matching up to your responsibilities, we expect the same from you. We are a fast growing company with individuals who, day-to-day, have to wear many hats and spin many plates at times. Please bear with us if we can't always match up to our responsibilities as outlined above. :smile:
+When things aren't going so well for you in meeting your responsibilities we will do our best to be flexible and understanding. We also expect the same from you.
+We are a fast growing company with individuals who, day-to-day, have to wear many hats and spin many plates at times. Please bear with us if we can't always match up to our responsibilities as outlined above. :smile:

--- a/docs/experts/expectations.md
+++ b/docs/experts/expectations.md
@@ -17,6 +17,9 @@ At the start of each work session, publish a self-stand-up via Slack, to include
 - What you achieved last session
 - What Jira ticket you will be working on this session
 
+Attend the regular, in-person stand-up calls, as agreed with us.
+These are typically held weekly.
+
 You must flag via Slack when you are running low on work.
 We'll then work with you to line up the next series of Jira tickets.
 


### PR DESCRIPTION
Includes content from [this internal Wiki page](https://ably.atlassian.net/wiki/spaces/DEL/pages/895090726/Managing+our+freelancers).

You can see _a_ rendered version of this document [here](https://github.com/ably/ably.github.io/blob/expert-expectations/docs/experts/expectations.md), however I'm yet to work out a system for this (still incubating) repository for previewing the GitHub Pages rendering for pull requests (i.e. in a Jekyll context). I've also got work to do on the Jekyll theme / layout (everything is default, out-of-the-box GitHub Pages right now).

This particular document has been identified as an immediate priority for publication, so while I acknowledge that there is yet to be an internal decision record defined to validate the creation of the GitHub pages site at ably.github.io and/or whether it ultimiately gets `CNAME`'d or not (see [this internal Slack thread](https://ably-real-time.slack.com/archives/CURL4U2FP/p1635939554012600)), I would appreciate it if reviewers could focus on the content - regardless of whether it ends up in a different home eventually.

**TL;DR:** Reviewers, please focus on the _what_, not the _how_.